### PR TITLE
--- réalisé --- 28/04/25:

### DIFF
--- a/Lancement.py
+++ b/Lancement.py
@@ -1,4 +1,6 @@
 from LesAventuriersDuRail import *
+from collections import Counter
+
 
 if __name__ == "__main__":
     print("\n=== Lancement manuel du jeu Les Aventuriers du Rail ===")
@@ -6,6 +8,11 @@ if __name__ == "__main__":
     # Création des joueurs
     joueurs = [Joueur("Alice", "rouge"), Joueur("Bob", "bleu")]
     table = Table(joueurs)
+    
+    #creation du plateau 
+    plateau = Plateau(VILLES_USA,ROUTES_USA)
+    plateau.routes[0].etat = "capturée"  # Marquer la première route comme capturée
+    #L'état capturé fonctionne car la route[0] est en pointillé
 
     # Initialisation de la partie
     print("\n=== Initialisation de la partie ===")
@@ -23,12 +30,24 @@ if __name__ == "__main__":
     while True:
         print(f"\n--- Tour {tour} ---")
         for joueur in joueurs:
+            
             print(f"\n{joueur.nom}, c'est votre tour !")
+            # Compter les occurrences des couleurs dans les cartes du joueur
+            couleurs_cartes = Counter(c.couleur for c in joueur.cartes_wagon)
+
+            # Afficher les cartes avec leur fréquence
+            print("Voici vos cartes wagon :")
+            for couleur, count in couleurs_cartes.items():
+                print(f"{couleur}: {count}")
+
+            print("Voici vos cartes destination :", [f"{c.ville_depart} → {c.ville_arrivee}" for c in joueur.cartes_defi])
+            
             print("1. Piocher une carte wagon")
             print("2. Capturer une route")
             print("3. Piocher des cartes destination")
-            print("4. Quitter le jeu")
-            choix = input("Choisissez une action (1, 2, 3, 4) : ")
+            print("4. afficher le plateau")
+            print("5. Quitter le jeu")
+            choix = input("Choisissez une action (1, 2, 3, 4, 5) : ")
 
             if choix == "1":
                 table.piocher_cartes_wagon(joueur)
@@ -37,6 +56,8 @@ if __name__ == "__main__":
             elif choix == "3":
                 table.piocher_cartes_itineraire(joueur)
             elif choix == "4":
+                plateau.afficher_plateau_graphique()
+            elif choix == "5":
                 print("Fin de la partie. Merci d'avoir joué !")
                 exit()
             else:

--- a/rq.txt
+++ b/rq.txt
@@ -1,0 +1,36 @@
+si c'est gris, j'aimerai choisir quelle couleur j'utilise
+lorsque on acquiert une route, choisir quels wagons utiliser
+
+Si je n'ai pas les cartes nécessaires, je veux pouvoir retourner en arrière automatiquement sur le choix à faire.
+
+si on repose une carte dest on réaffiche les cartes entrain d'etres choisir
+
+
+rechoisir après faux choix
+si un choix est invalide, redonner la main à celui qui vient de faire le mauvais choix
+
+
+je n'arrive pas à capturer une route
+
+
+
+--- en cours ---
+
+actualiser l'affichage du plateau avec les routes occupés (état occupé ou libre), et leur longueur
+possiblement choisir 5 pour actualiser la carte.
+
+
+
+--- réalisé ---
+28/04/25:
+
+problème des 3 locomotives
+
+on affiche regulièrement les cartes du joueur pour qui c'est le tour
+print les cartes possédés par le joueur au début de son tour. et modifier la présentation en mettant "nb x couleur"
+
+ajout d'un état capturé dans Route et début de méthode capturer
+
+modification de plateau pour les routes capturées (style/ couleur/ affichage)
+L'état capturé fonctionne car la route[0] est en pointillé
+Mais la capture n'est pas réussi


### PR DESCRIPTION
problème des 3 locomotives

on affiche regulièrement les cartes du joueur pour qui c'est le tour print les cartes possédés par le joueur au début de son tour. et modifier la présentation en mettant "nb x couleur"

ajout d'un état capturé dans Route et début de méthode capturer

modification de plateau pour les routes capturées (style/ couleur/ affichage) L'état capturé fonctionne car la route[0] est en pointillé Mais la capture n'est pas réussi